### PR TITLE
Update Run.sh to use pytest with virtual environment

### DIFF
--- a/Tests/Run.sh
+++ b/Tests/Run.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-python run.py
+cd ..
+source .venv/bin/activate
+pytest Tests/


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Change Tests/Run.sh to activate the project virtual environment and run pytest on the Tests directory instead of invoking the previous test runner script.