### PR TITLE
Enhance create_app with test config and greeting

### DIFF
--- a/Tests/src/app_init_.py
+++ b/Tests/src/app_init_.py
@@ -1,14 +1,36 @@
 from flask import Flask
+import os
 
-def create_app():
-    app = Flask(__name__)
+def create_app(test_config=None):
+    # Cria e configura a instância do app
+    app = Flask(__name__, 
+                instance_relative_config=True,
+                template_folder='../../templates',
+                static_folder='../../Static')
 
+    if test_config is None:
+        # Carrega a configuração de instância, se existir, quando não estiver testando
+        app.config.from_mapping(
+            SECRET_KEY='dev',
+        )
+    else:
+        # Carrega a configuração de teste se passada
+        app.config.from_mapping(test_config)
+
+    # Comando CLI de saudação
     @app.cli.command("saudacao")
     def saudacao():
         """Exibe uma mensagem de saudação personalizada."""
-        print("Olá! Bem-vindo ao Estrutura-do-Projeto 🎉")
+        print("Olá! Bem-vindo ao Estrutura-do-Projeto 🎉 (Modo Teste)")
 
-    from . import routes
-    app.register_blueprint(routes.bp)
+    # Importante: O registro de rotas deve apontar para o local correto
+    # Para testes, podemos usar as rotas principais ou mocks
+    try:
+        from python import routes
+        app.register_blueprint(routes.app) # Se usar Blueprint, ajuste para .bp
+    except ImportError:
+        @app.route('/')
+        def index():
+            return "App de Teste Ativo"
 
     return app


### PR DESCRIPTION
Refactor create_app function to include test configuration and update greeting message.

## Summary by Sourcery

Refactor the Flask application factory to support test-specific configuration, adjust resource paths, and provide a fallback route when route registration fails.

New Features:
- Allow passing a test configuration mapping into the Flask application factory.
- Add a CLI greeting command variant that indicates test mode and adjust application templates and static folders.
- Provide a fallback index route for tests when the standard routes module cannot be imported.